### PR TITLE
fix(ExamplePlugin): Make MediaItem title awaited before displaying it

### DIFF
--- a/plugins/Example/src/index.ts
+++ b/plugins/Example/src/index.ts
@@ -17,4 +17,7 @@ export const unloads = new Set<LunaUnload>();
 // Log to console whenever changing page
 redux.intercept("page/SET_PAGE_ID", unloads, console.log);
 
-MediaItem.onMediaTransition(unloads, (mediaItem) => alert(`Media item transitioned: ${mediaItem.title}`));
+MediaItem.onMediaTransition(unloads, async (mediaItem) => {
+    const title = await mediaItem.title();
+    alert(`Media item transitioned: ${title}`);
+});


### PR DESCRIPTION
In the ExamplePlugin there's an example `onMediaTransition` listener implementation that displays new track title.

`MediaItem.title` is an async method, but in the mentioned example it's treated as a string which results
in function code being displayed in the alert instead of intended title:
![image](https://github.com/user-attachments/assets/ae1fbda0-9581-420e-9a1f-e25d72ddb004)

This PR fixes this issue by making the listener async and awaiting the result of `title` method.
